### PR TITLE
Corrige nomes de pré configuração e permite edição

### DIFF
--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -76,6 +76,23 @@ def parse_create():
     validate_preconfig_post(response.status_code, saved_preconfig)
 
 
+def parse_change_name(pre_config_id, new_name):
+    response = requests.patch(
+        BASE_URL + f"pre-configs/{pre_config_id}", json={"name": new_name}
+    )
+
+    response_data = response.json()
+
+    if 200 <= response.status_code <= 299:
+        print(
+            f'Your Pre Configuration name was succesfully changed to "{response_data["name"]}"'
+        )
+    else:
+        print(
+            f"There was an ERROR while changing your Pre Configuration name:  {response_data['error']}"
+        )
+
+
 def setup():
     parser = argparse.ArgumentParser(
         description="Command line interface for measuresoftgram"
@@ -99,6 +116,22 @@ def setup():
 
     subparsers.add_parser("create", help="Create a new model pre configuration")
 
+    change_name = subparsers.add_parser(
+        "change-name", help="Change pre configuration name"
+    )
+
+    change_name.add_argument(
+        "pre_config_id",
+        type=str,
+        help="Pre config ID",
+    )
+
+    change_name.add_argument(
+        "new_name",
+        type=str,
+        help="New pre configuration name",
+    )
+
     args = parser.parse_args()
 
     # if args is empty show help
@@ -109,6 +142,8 @@ def setup():
         parse_import(args.path, args.id)
     elif args.command == "create":
         parse_create()
+    elif args.command == "change-name":
+        parse_change_name(args.pre_config_id, args.new_name)
 
 
 def main():

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -4,7 +4,6 @@ import sys
 import requests
 import signal
 from pathlib import Path
-from random import randrange
 from src.cli.exceptions import MeasureSoftGramCLIException
 from src.cli.jsonReader import file_reader, validate_metrics_post
 from src.cli.create import (

--- a/src/cli/cliRunner.py
+++ b/src/cli/cliRunner.py
@@ -60,10 +60,7 @@ def parse_create():
         "measures",
     )
 
-    pre_config_name = f"msg_pre_config_{randrange(5)}"
-
     data = {
-        "name": pre_config_name,
         "characteristics": user_characteristics,
         "subcharacteristics": user_sub_characteristic,
         "measures": user_measures,

--- a/tests/unit/test_change_name.py
+++ b/tests/unit/test_change_name.py
@@ -1,0 +1,60 @@
+import pytest
+from io import StringIO
+from src.cli.cliRunner import parse_change_name
+
+
+class DummyResponse:
+    def __init__(self, status_code, res_data):
+        self.status_code = status_code
+        self.res_data = res_data
+
+    def json(self):
+        return self.res_data
+
+
+def test_change_name_sucess(mocker):
+    res_data = {
+        "_id": "6261b76c974ddbc76bdea7af",
+        "name": "pre-config-one",
+        "characteristics": {},
+        "subcharacteristics": {},
+        "measures": [],
+        "created_at": "2022-04-21 19:58:36+00:00",
+    }
+
+    mocker.patch("requests.patch", return_value=DummyResponse(200, res_data))
+
+    with mocker.patch("sys.stdout", new=StringIO()) as fake_out:
+        parse_change_name("6261b76c974ddbc76bdea7af", "pre-config-1")
+
+        expected = (
+            'Your Pre Configuration name was succesfully changed to "pre-config-one"'
+        )
+
+        assert expected in fake_out.getvalue()
+
+
+@pytest.mark.parametrize(
+    "status_code, error_msg",
+    [
+        (
+            404,
+            "There was an ERROR while changing your Pre Configuration name: "
+            + "There is no pre configurations with ID 6261b76c974ddbc76bdea7af",
+        ),
+        (
+            422,
+            "There was an ERROR while changing your Pre Configuration name: "
+            + "The pre config name is already in use",
+        ),
+    ],
+)
+def test_change_name_error(mocker, status_code, error_msg):
+    res_data = {"error": error_msg}
+
+    mocker.patch("requests.patch", return_value=DummyResponse(status_code, res_data))
+
+    with mocker.patch("sys.stdout", new=StringIO()) as fake_out:
+        parse_change_name("6261b76c974ddbc76bdea7af", "pre-config-1")
+
+        assert error_msg in fake_out.getvalue()


### PR DESCRIPTION
## Descrição
Corrige problema de geração de nome de pré configuração. Para melhorar a usabilidade também permite edição de nome de pré configuração.

[Editar nome da pré configuração](https://github.com/fga-eps-mds/2021-2-MeasureSoftGram-Doc/issues/174)

## Porque este Pull Request é necessário?
Integrar no produto a correção da geração de nomes e edição de nome de pré configuração.

## Critérios de aceitação

1. [ ] ?

Closes #174
