### PR TITLE
Fix import error with pytz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ from setuptools import setup, find_packages
 
 setup(
     name="measuresoftgram",
-    version="2.0.5",
+    version="2.0.6",
     extras_require={"dev": ["pytest", "pytest-cov", "setuptools", "wheel"]},
     packages=find_packages(),
-    install_requires=["inquirer==2.8.0", "requests"],
+    install_requires=["inquirer==2.8.0", "requests", "pytz"],
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and allow
     # pip to create the appropriate form of executable for the target platform.


### PR DESCRIPTION
# Adiciona pytz nas dependências

## Descrição
Permite que o measuresoftgram rode sem erros de import
